### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,14 +21,6 @@ Requirements
 Installation
 ------------
 
-Arch Linux
-~~~~~~~~~~
-
-The package is available on AUR (``yoga-image-optimizer``):
-
-* https://aur.archlinux.org/packages/yoga-image-optimizer
-
-
 Flatpak (Linux)
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Removed Arch Linux AUR installation entry as it was unfortunately removed from the AUR 13 Nov 2023.

The record of that request, and followup can be found here:

- [[PRQ#50821] Deletion Request for yoga-image-optimizer](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/message/ZLRAO5H4QP2AKXY7NN2IMFJIKYFYKP74/)
- [[PRQ#50821] Deletion Request for yoga-image-optimizer Accepted](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/message/SJMNRQCNYQRG6S2HVF46SJY27VV655XU/)